### PR TITLE
Issue#1

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,10 @@ class Termit {
 
 	saveFile() {
 		this.hookChain(()=>{
+			if(this.getText() == ''){
+				return;
+			}
+
 			if (this.currentFile) {
 				this.save(this.currentFile);
 			} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "termit",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termit",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A simple terminal editor",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixed issue#1 for normal save. Save As is considered an overriding action anyway, so saving an empty document is permitted.