### PR TITLE
Added CTRL+Arrow Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,6 +363,18 @@ class Termit {
 			case 'ENTER':
 				this.newLine();
 				break;
+			case 'CTRL_UP':
+				this.pgUp();
+				break;
+			case 'CTRL_DOWN':
+				this.pgDown();
+				break;
+			case 'CTRL_LEFT':
+				this.startOfLine();
+				break;
+			case 'CTRL_RIGHT':
+				this.endOfLine();
+				break;	
 			default:
 				if (data.isCharacter) {
 					this.textBuffer.insert(key);


### PR DESCRIPTION
Fixes #11 
Ok so there is already support for the CTRL-Arrow key events on terminal-kit (Guess they gotta update their documentation on npmjs. I found this on their GitHub but not on the npmjs website)
The aliases are as below.
| Key      | Alias |
| ----------- | ----------- |
| CTRL+Up      | PageUp       |
| CTRL+Down   | PageDown        |
| CTRL+Right   | End of The Line        |
| CTRL+Left   | Start of The Line        |

Please let me know if it needs anything.
I can add it to the readme as well